### PR TITLE
Feature/test drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ typings/
 
 # ignore dynamically created dist directory
 dist
+
+# WebStorm IDE settings
+.idea

--- a/gulp.config.json
+++ b/gulp.config.json
@@ -103,6 +103,6 @@
   ],
   "dest": "dist",
   "src": "src",
-  "zip": "breakfast-butter.zip",
+  "zip": "atomic-reactor-toolkit.zip",
   "hooks": {}
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "engines": {
     "node": ">=7.8.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
@@ -70,9 +70,7 @@
     "vinyl-source-stream": "^1.1.0",
     "webpack": "^2.2.1",
     "yargs": "^8.0.2",
-    "zip-folder": "^1.0.0"
-  },
-  "dependencies": {
+    "zip-folder": "^1.0.0",
     "express": "4.15.2",
     "http-auth": "^3.1.3",
     "moment": "^2.17.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "node": ">=7.8.0"
   },
   "dependencies": {
+    "ajv": "^5.5.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.0.0",
     "babel-preset-es2015": "^6.24.1",
@@ -45,6 +46,7 @@
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.4.0",
+    "express": "4.15.2",
     "fs-extra": "^3.0.1",
     "gulp": "^3.9.1",
     "gulp-autoprefixer": "^3.1.0",
@@ -60,23 +62,22 @@
     "handlebars-cond": "^1.0.3",
     "handlebars-lipsum": "^1.0.7",
     "handlebars-loop": "^1.0.2",
+    "http-auth": "^3.1.3",
     "imports-loader": "^0.6.5",
     "jquery": "^3.2.1",
     "js-beautify": "^1.6.11",
+    "moment": "^2.17.1",
+    "nodemon": "^1.11.0",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "run-sequence": "^1.2.1",
     "script-loader": "^0.7.0",
+    "slugify": "^1.1.0",
     "uglifyjs-webpack-plugin": "^0.4.3",
     "underscore": "^1.8.3",
     "vinyl-source-stream": "^1.1.0",
     "webpack": "^2.2.1",
     "yargs": "^8.0.2",
-    "zip-folder": "^1.0.0",
-    "express": "4.15.2",
-    "http-auth": "^3.1.3",
-    "moment": "^2.17.1",
-    "nodemon": "^1.11.0",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
-    "slugify": "^1.1.0"
+    "zip-folder": "^1.0.0"
   }
 }

--- a/src/assets/ar/scripts/toggler.js
+++ b/src/assets/ar/scripts/toggler.js
@@ -3,6 +3,8 @@ const _          = require('underscore');
 const config     = require('../../../data/toolkit.json');
 const slugify    = require('slugify');
 
+var $ = jQuery;
+
 /**
  * -----------------------------------------------------------------------------
  * Constructor
@@ -61,7 +63,7 @@ toggler.toggle = function (id, state) {
 toggler.expand = function () {
     let prefix    = slugify(config.name.toLowerCase());
     let exp       = window.localStorage.getItem(prefix + '-expanded');
-    exp           = (typeof exp !== 'undefined') ? JSON.parse(exp) : [];
+    exp           = (typeof exp !== 'undefined' && exp !== null) ? JSON.parse(exp) : [];
     let inter     = _.intersection(toggler.controls, exp);
 
     $('.f-global-control').removeClass('f-active');


### PR DESCRIPTION
I fixed some problems that existed in the unmodified Toolkit code.

Critical problems fixed:
* the local server would crash whenever you changed any script file (during the scripts watch)
* "ar.js" would threw run-time errors as soon as it loaded

Major problem fixed:
* changed devDependencies to dependencies because otherwise `npm start` in prod mode will always serve only 404's (because it can't build anything without devDependencies, and there's no cross-environment file migration mechanism)

Minor problems fixed:
* cleaned up some warnings and other annoyances
