### PR TITLE
include css optimizer in local build and disable restructuring

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -130,7 +130,7 @@ gulp.task('styles:ar', () => {
 		.pipe(sourcemaps.init())
 		.pipe(sass().on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
-		.pipe(gulpif(!config.dev, csso()))
+		.pipe(csso({restructure: false}))
 		.pipe(rename('ar.css'))
 		.pipe(sourcemaps.write())
 		.pipe(gulp.dest(config.styles.ar.dest))
@@ -144,7 +144,7 @@ gulp.task('styles:toolkit', () => {
 			includePaths: ['./node_modules'],
 		}).on('error', sass.logError))
 		.pipe(prefix('last 1 version'))
-		.pipe(gulpif(!config.dev, csso()))
+		.pipe(csso({restructure: false}))
 		.pipe(gulpif(config.dev, sourcemaps.write()))
 		.pipe(gulp.dest(config.styles.toolkit.dest))
 		.pipe(gulpif(config.dev, reload({stream: true})));


### PR DESCRIPTION
I'm changing the Gulpfile to correct a problem we encountered in a private clone of `Toolkit`. I'm disabling the `restructure` setting in `csso`, because we found cases where it caused functional differences (which an optimizer should NEVER do), and it's very difficult to troubleshoot when it happens. In our clone, the effect of disabling `restructure` did not increase the output size significantly. The file `toolkit.css` went from 212 KB to 216 KB.

In addition to changing the `csso` configuration, I'm also making it unconditional, that is, applying to both "dev" and "prod" environments. This way, even if `csso` is capable of causing other functional differences, whatever developers see locally is guaranteed to be identical to what is deployed to a production (or test) server. In our clone, the effect of including `csso` in the "dev" build did not significantly increase the build time. It added 0.135 seconds (maximum observed delta in 4 test runs) to the total resulting time of 7.68 seconds.